### PR TITLE
feat: add x-invocation-id to response headers

### DIFF
--- a/src/azure-adapter.js
+++ b/src/azure-adapter.js
@@ -12,7 +12,7 @@
 /* eslint-disable no-param-reassign, no-underscore-dangle, import/no-extraneous-dependencies */
 const { Request } = require('@adobe/helix-fetch');
 const {
-  isBinary, ensureUTF8Charset, updateProcessEnv, cleanupHeaderValue,
+  isBinary, ensureUTF8Charset, ensureInvocationId, updateProcessEnv, cleanupHeaderValue,
 } = require('./utils.js');
 const { AzureResolver } = require('./resolver.js');
 
@@ -81,6 +81,7 @@ async function azure(context, req) {
 
     const response = await main(request, con);
     ensureUTF8Charset(response);
+    ensureInvocationId(response, con);
 
     context.res = {
       status: response.status,
@@ -95,7 +96,8 @@ async function azure(context, req) {
       context.res = {
         status: 400,
         headers: {
-          'Content-Type': 'text/plain',
+          'content-type': 'text/plain',
+          'x-invocation-id': context.invocationId,
         },
         body: e.message,
       };
@@ -106,8 +108,9 @@ async function azure(context, req) {
     context.res = {
       status: 500,
       headers: {
-        'Content-Type': 'text/plain',
+        'content-type': 'text/plain',
         'x-error': cleanupHeaderValue(e.message),
+        'x-invocation-id': context.invocationId,
       },
       body: e.message,
     };

--- a/src/openwhisk-adapter.js
+++ b/src/openwhisk-adapter.js
@@ -14,7 +14,8 @@ const querystring = require('querystring');
 const { Request } = require('@adobe/helix-fetch');
 const { epsagon } = require('@adobe/helix-epsagon');
 const {
-  isBinary, ensureUTF8Charset, updateProcessEnv, HEALTHCHECK_PATH, cleanupHeaderValue,
+  isBinary, ensureUTF8Charset, ensureInvocationId, updateProcessEnv, HEALTHCHECK_PATH,
+  cleanupHeaderValue,
 } = require('./utils.js');
 
 const { OpenwhiskResolver } = require('./resolver.js');
@@ -110,6 +111,7 @@ async function openwhiskAdapter(params) {
 
     const response = await main(request, context);
     ensureUTF8Charset(response);
+    ensureInvocationId(response, context);
 
     const isBase64Encoded = isBinary(response.headers.get('content-type'));
     return {
@@ -125,6 +127,7 @@ async function openwhiskAdapter(params) {
         statusCode: 400,
         headers: {
           'Content-Type': 'text/plain',
+          'x-invocation-id': process.env.__OW_ACTIVATION_ID,
         },
         body: e.message,
       };
@@ -135,6 +138,7 @@ async function openwhiskAdapter(params) {
       statusCode: 500,
       headers: {
         'Content-Type': 'text/plain',
+        'x-invocation-id': process.env.__OW_ACTIVATION_ID,
         'x-error': cleanupHeaderValue(e.message),
       },
       body: 'Internal Server Error',

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,6 +54,19 @@ function ensureUTF8Charset(resp) {
 }
 
 /**
+ * Sets the 'x-invocation-id' to the response header it not already present.
+ * @param {Response} resp the response
+ * @param {UniversalContext} context the context
+ * @return {Response} the same response
+ */
+function ensureInvocationId(resp, context) {
+  if (!resp.headers.has('x-invocation-id')) {
+    resp.headers.set('x-invocation-id', context.invocation.id);
+  }
+  return resp;
+}
+
+/**
  * Updates the process environment with function information.
  * (note that we don't set the invocation id, since not all runtimes isolate the process env)
  * @param {UniversalContext} context The context
@@ -80,6 +93,7 @@ const HEALTHCHECK_PATH = '/_status_check/healthcheck.json';
 module.exports = {
   isBinary,
   ensureUTF8Charset,
+  ensureInvocationId,
   updateProcessEnv,
   cleanupHeaderValue,
   HEALTHCHECK_PATH,

--- a/test/adapter-utils.test.js
+++ b/test/adapter-utils.test.js
@@ -15,7 +15,7 @@
 
 const assert = require('assert');
 const { Response } = require('@adobe/helix-fetch');
-const { isBinary, ensureUTF8Charset } = require('../src/utils.js');
+const { isBinary, ensureUTF8Charset, ensureInvocationId } = require('../src/utils.js');
 
 describe('Adapter Utils Tests: ensureUTF8Encoding', () => {
   it('defaults missing charset-type header to text/plain', async () => {
@@ -68,6 +68,30 @@ describe('Adapter Utils Tests: ensureUTF8Encoding', () => {
 
   it('errors if plain response headers', () => {
     assert.throws(() => ensureUTF8Charset({ headers: {} }), Error('response.headers has no method "get()"'));
+  });
+});
+
+describe('Adapter Utils Tests: ensureInvocationId', () => {
+  it('adds missing invocation id', async () => {
+    const resp = ensureInvocationId(new Response(), {
+      invocation: {
+        id: 'foobar',
+      },
+    });
+    assert.equal(resp.headers.get('x-invocation-id'), 'foobar');
+  });
+
+  it('ignores invocation id if already set', async () => {
+    const resp = ensureInvocationId(new Response('', {
+      headers: {
+        'x-invocation-id': 'my-id',
+      },
+    }), {
+      invocation: {
+        id: 'foobar',
+      },
+    });
+    assert.equal(resp.headers.get('x-invocation-id'), 'my-id');
   });
 });
 

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -100,6 +100,10 @@ describe('Adapter tests for AWS', () => {
     });
     const res = await lambda(DEFAULT_EVENT, DEFAULT_CONTEXT);
     assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.headers, {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-invocation-id': '535f0399-9c90-4042-880e-620cfec6af55',
+    });
   });
 
   it('context.invocation (external transaction id)', async () => {
@@ -142,6 +146,10 @@ describe('Adapter tests for AWS', () => {
       },
     }, DEFAULT_CONTEXT);
     assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.headers, {
+      'content-type': 'text/plain',
+      'x-invocation-id': '535f0399-9c90-4042-880e-620cfec6af55',
+    });
   });
 
   it('handles error in function', async () => {
@@ -160,7 +168,11 @@ describe('Adapter tests for AWS', () => {
       },
     }, DEFAULT_CONTEXT);
     assert.equal(res.statusCode, 500);
-    assert.equal(res.headers['x-error'], 'function kaput');
+    assert.deepEqual(res.headers, {
+      'content-type': 'text/plain',
+      'x-error': 'function kaput',
+      'x-invocation-id': '535f0399-9c90-4042-880e-620cfec6af55',
+    });
   });
 
   it('handles error in epsagon wrapper', async () => {
@@ -181,7 +193,11 @@ describe('Adapter tests for AWS', () => {
       },
     }, DEFAULT_CONTEXT);
     assert.equal(res.statusCode, 500);
-    assert.equal(res.headers['x-error'], 'epsagon wrapper kaput');
+    assert.deepEqual(res.headers, {
+      'content-type': 'text/plain',
+      'x-error': 'epsagon wrapper kaput',
+      'x-invocation-id': '535f0399-9c90-4042-880e-620cfec6af55',
+    });
   });
 
   it('flushes log', async () => {

--- a/test/azure-adapter.test.js
+++ b/test/azure-adapter.test.js
@@ -31,6 +31,7 @@ describe('Adapter tests for Azure', () => {
     });
 
     const context = {
+      invocationId: '1234',
       // eslint-disable-next-line no-console
       log: console.log,
       executionContext: {
@@ -44,6 +45,10 @@ describe('Adapter tests for Azure', () => {
 
     await azure(context, request);
     assert.equal(context.res.status, 200, context.res.body);
+    assert.deepEqual(context.res.headers, {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-invocation-id': '1234',
+    });
   });
 
   it('handles illegal request headers with 400', async () => {
@@ -57,6 +62,7 @@ describe('Adapter tests for Azure', () => {
     });
 
     const context = {
+      invocationId: '1234',
       // eslint-disable-next-line no-console
       log: console.log,
       executionContext: {
@@ -73,6 +79,10 @@ describe('Adapter tests for Azure', () => {
 
     await azure(context, request);
     assert.equal(context.res.status, 400, context.res.body);
+    assert.deepEqual(context.res.headers, {
+      'content-type': 'text/plain',
+      'x-invocation-id': '1234',
+    });
   });
 
   it('handles recognizes the x-backup-content-type', async () => {
@@ -121,6 +131,7 @@ describe('Adapter tests for Azure', () => {
     });
 
     const context = {
+      invocationId: '1234',
       // eslint-disable-next-line no-console
       log: console.log,
       executionContext: {
@@ -137,7 +148,11 @@ describe('Adapter tests for Azure', () => {
     };
 
     await azure(context, request);
-    assert.equal(context.res.headers['x-error'], 'function kaput');
+    assert.deepEqual(context.res.headers, {
+      'content-type': 'text/plain',
+      'x-invocation-id': '1234',
+      'x-error': 'function kaput',
+    });
   });
 
   it('set correct context and environment', async () => {

--- a/test/google-adapter.test.js
+++ b/test/google-adapter.test.js
@@ -74,10 +74,15 @@ describe('Adapter tests for Google', () => {
 
     const req = createMockRequest('/helix-services--content-proxy_4.3.1/foo/bar', {
       host: 'us-central1-helix-225321.cloudfunctions.net',
+      'function-execution-id': '1234',
     });
     const res = createMockResponse();
     await google(req, res);
     assert.equal(res.code, 200);
+    assert.deepEqual(res.headers, {
+      'content-type': 'text/plain; charset=utf-8',
+      'x-invocation-id': '1234',
+    });
   });
 
   it('context.func', async () => {
@@ -147,11 +152,16 @@ describe('Adapter tests for Google', () => {
     });
     const req = createMockRequest('/api/simple-package/simple-name/1.45.0/foo', {
       host: 'us-central1-helix-225321.cloudfunctions.net',
+      'function-execution-id': '1234',
     });
     const res = createMockResponse();
     await google(req, res);
     assert.equal(res.code, 500);
-    assert.equal(res.headers['x-error'], 'function kaput');
+    assert.deepEqual(res.headers, {
+      'content-type': 'text/plain',
+      'x-error': 'function kaput',
+      'x-invocation-id': '1234',
+    });
   });
 
   it('handle binary response body', async () => {

--- a/test/openwhisk-adapter.test.js
+++ b/test/openwhisk-adapter.test.js
@@ -87,6 +87,7 @@ describe('OpenWhisk Adapter Test', () => {
       body: '',
       headers: {
         'content-type': 'text/plain; charset=utf-8',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -115,6 +116,7 @@ describe('OpenWhisk Adapter Test', () => {
       },
       headers: {
         'content-type': 'text/plain; charset=utf-8',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -147,6 +149,7 @@ describe('OpenWhisk Adapter Test', () => {
       },
       headers: {
         'content-type': 'text/plain; charset=utf-8',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -191,6 +194,7 @@ describe('OpenWhisk Adapter Test', () => {
       headers: {
         'content-type': 'text/plain; charset=utf-8',
         'x-last-activation-id': '1234',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -225,6 +229,7 @@ describe('OpenWhisk Adapter Test', () => {
       headers: {
         'content-type': 'text/plain; charset=utf-8',
         'x-last-activation-id': '1234',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -259,6 +264,7 @@ describe('OpenWhisk Adapter Test', () => {
       headers: {
         'content-type': 'text/plain; charset=utf-8',
         'x-last-activation-id': '1234',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -286,6 +292,7 @@ describe('OpenWhisk Adapter Test', () => {
       },
       headers: {
         'content-type': 'text/plain; charset=utf-8',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -316,6 +323,7 @@ describe('OpenWhisk Adapter Test', () => {
       },
       headers: {
         'content-type': 'text/plain; charset=utf-8',
+        'x-invocation-id': '1234',
       },
       statusCode: 200,
     });
@@ -341,6 +349,7 @@ describe('OpenWhisk Adapter Test', () => {
       headers: {
         'Content-Type': 'text/plain',
         'x-error': 'boing!',
+        'x-invocation-id': '1234',
       },
       statusCode: 500,
     });


### PR DESCRIPTION
for openwhisk actions there was the x-activation-id returned that could be used to trace action invocations.
by adding the `context.invocation.id` as `x-invocation-id` header, it will be easier to find the functions.