### PR TITLE
fix(google): avoid dots in package name for secrets

### DIFF
--- a/src/google-package-params.js
+++ b/src/google-package-params.js
@@ -12,7 +12,7 @@
 
 async function getGoogleSecrets(functionName, projectID) {
   const parent = `projects/${projectID}`;
-  const package = functionName.replace(/--.*/, '');
+  const package = functionName.replace(/--.*/, '').replace(/\./g, '_');
   const name = `${parent}/secrets/helix-deploy--${package}/versions/latest`;
   try {
     // delay the import so that other runtimes do not have to care


### PR DESCRIPTION
as they are illegal in google and not supported in helix-deploy since adobe/helix-deploy#223

fixes adobe/helix-deploy#222
