### PR TITLE
feat: allow to run AWS function without API gateway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/helix-universal",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/helix-universal",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/helix-epsagon": "1.6.4",

--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -139,6 +139,20 @@ async function lambda(evt, ctx) {
         });
       }
     }
+    if (!evt.requestContext) {
+      // function was invoked directly, not through API Gateway
+      const searchParams = new URLSearchParams();
+      Object.getOwnPropertyNames(evt).forEach((name) => {
+        const value = evt[name];
+        if (typeof value === 'string') {
+          searchParams.append(name, value);
+        }
+      });
+      evt.rawPath = '';
+      evt.rawQueryString = searchParams.toString();
+      evt.headers = {};
+      evt.requestContext = { http: {} };
+    }
     return handler(evt, ctx);
   } catch (e) {
     return {

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -331,4 +331,34 @@ describe('Adapter tests for AWS', () => {
     }, DEFAULT_CONTEXT);
     assert.equal(res.statusCode, 200);
   });
+
+  it('can be run without requestContext', async () => {
+    const lambda = proxyquire('../src/aws-adapter.js', {
+      './main.js': {
+        main: (request, context) => {
+          assert.deepStrictEqual(context.func, {
+            name: 'dump',
+            package: 'helix-pages',
+            version: '4.3.1',
+            fqn: 'arn:aws:lambda:us-east-1:118435662149:function:helix-pages--dump:4_3_1',
+            app: undefined,
+          });
+          const { searchParams } = new URL(request.url);
+          assert.strictEqual(searchParams.toString(), 'key1=value1&key2=value2&key3=value3');
+          return new Response('ok');
+        },
+      },
+      './aws-package-params.js': () => ({}),
+    });
+    const res = await lambda(
+      {
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+        other: {},
+      },
+      DEFAULT_CONTEXT,
+    );
+    assert.equal(res.statusCode, 200);
+  });
 });


### PR DESCRIPTION
possible fix for #12 

Allows one to run a function directly in the AWS console, passing parameters as event payload, or, more interesting, install a cron trigger with a simple payload.