### PR TITLE
use `import` for non toplevel module imports

### DIFF
--- a/src/aws-package-params.js
+++ b/src/aws-package-params.js
@@ -19,7 +19,7 @@ const cache = {
 async function loadAWSSecrets(functionName) {
   // delay the import so that other runtimes do not have to care
   // eslint-disable-next-line import/no-unresolved, global-require,import/no-extraneous-dependencies
-  const AWS = require('aws-sdk');
+  const AWS = await import('aws-sdk');
 
   AWS.config.update({
     region: process.env.AWS_REGION,

--- a/src/azure-adapter.js
+++ b/src/azure-adapter.js
@@ -25,7 +25,7 @@ const { AzureResolver } = require('./resolver.js');
 async function azure(context, req) {
   context.log('JavaScript HTTP trigger function processed a request.');
   // eslint-disable-next-line global-require, import/no-unresolved
-  const params = require('./params.json');
+  const params = await import('./params.json');
 
   let body;
   if (!/^(GET|HEAD)$/i.test(req.method)) {

--- a/src/google-package-params.js
+++ b/src/google-package-params.js
@@ -17,7 +17,7 @@ async function getGoogleSecrets(functionName, projectID) {
   try {
     // delay the import so that other runtimes do not have to care
     // eslint-disable-next-line  import/no-unresolved, global-require
-    const { SecretManagerServiceClient } = require('@google-cloud/secret-manager');
+    const { SecretManagerServiceClient } = await import('@google-cloud/secret-manager');
 
     // hope that the credentials appear by magic
     const client = new SecretManagerServiceClient();

--- a/src/google-package-params.js
+++ b/src/google-package-params.js
@@ -12,8 +12,8 @@
 
 async function getGoogleSecrets(functionName, projectID) {
   const parent = `projects/${projectID}`;
-  const package = functionName.replace(/--.*/, '').replace(/\./g, '_');
-  const name = `${parent}/secrets/helix-deploy--${package}/versions/latest`;
+  const packageName = functionName.replace(/--.*/, '').replace(/\./g, '_');
+  const name = `${parent}/secrets/helix-deploy--${packageName}/versions/latest`;
   try {
     // delay the import so that other runtimes do not have to care
     // eslint-disable-next-line  import/no-unresolved, global-require


### PR DESCRIPTION
seems to work better with rollup