### PR TITLE
fix: support delivery failure

### DIFF
--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -143,17 +143,20 @@ async function lambda(evt, ctx) {
 
     const secrets = await getAWSSecrets(ctx.functionName);
     let handler = (event, context) => lambdaAdapter(event, context, secrets);
-    if (secrets.EPSAGON_TOKEN && !evt.nonHttp) {
-      // check if health check
-      const suffix = evt.pathParameters && evt.pathParameters.path ? `/${evt.pathParameters.path}` : '';
-      if (suffix !== HEALTHCHECK_PATH) {
-        handler = epsagon(handler, {
-          token: secrets.EPSAGON_TOKEN,
-        });
+
+    if (!evt.nonHttp) {
+      // do not use Epsagon otherwise as it currently reports issues for functions that throw
+      if (secrets.EPSAGON_TOKEN && !evt.nonHttp) {
+        // check if health check
+        const suffix = evt.pathParameters && evt.pathParameters.path ? `/${evt.pathParameters.path}` : '';
+        if (suffix !== HEALTHCHECK_PATH) {
+          handler = epsagon(handler, {
+            token: secrets.EPSAGON_TOKEN,
+          });
+        }
       }
-    }
-    if (evt.nonHttp) {
-      // not through Gateway API, so mimic minimal requirements
+    } else {
+      // mimic minimal requirements for our environment setup in lambdaAdapter
       const searchParams = new URLSearchParams();
       Object.getOwnPropertyNames(evt).forEach((name) => {
         const value = evt[name];

--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -146,7 +146,7 @@ async function lambda(evt, ctx) {
 
     if (!evt.nonHttp) {
       // do not use Epsagon otherwise as it currently reports issues for functions that throw
-      if (secrets.EPSAGON_TOKEN && !evt.nonHttp) {
+      if (secrets.EPSAGON_TOKEN) {
         // check if health check
         const suffix = evt.pathParameters && evt.pathParameters.path ? `/${evt.pathParameters.path}` : '';
         if (suffix !== HEALTHCHECK_PATH) {

--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -144,18 +144,16 @@ async function lambda(evt, ctx) {
     const secrets = await getAWSSecrets(ctx.functionName);
     let handler = (event, context) => lambdaAdapter(event, context, secrets);
 
-    if (!evt.nonHttp) {
-      // do not use Epsagon otherwise as it currently reports issues for functions that throw
-      if (secrets.EPSAGON_TOKEN) {
-        // check if health check
-        const suffix = evt.pathParameters && evt.pathParameters.path ? `/${evt.pathParameters.path}` : '';
-        if (suffix !== HEALTHCHECK_PATH) {
-          handler = epsagon(handler, {
-            token: secrets.EPSAGON_TOKEN,
-          });
-        }
+    if (secrets.EPSAGON_TOKEN) {
+      // check if health check
+      const suffix = evt.pathParameters && evt.pathParameters.path ? `/${evt.pathParameters.path}` : '';
+      if (suffix !== HEALTHCHECK_PATH) {
+        handler = epsagon(handler, {
+          token: secrets.EPSAGON_TOKEN,
+        });
       }
-    } else {
+    }
+    if (evt.nonHttp) {
       // mimic minimal requirements for our environment setup in lambdaAdapter
       const searchParams = new URLSearchParams();
       Object.getOwnPropertyNames(evt).forEach((name) => {

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -402,4 +402,46 @@ describe('Adapter tests for AWS', () => {
     );
     assert.equal(res.statusCode, 200);
   });
+
+  it('handles errors when run without requestContext', async () => {
+    const lambda = proxyquire('../src/aws-adapter.js', {
+      './main.js': {
+        main: () => {
+          throw new Error('function kaput');
+        },
+      },
+      './aws-package-params.js': () => ({}),
+    });
+    await assert.rejects(async () => lambda(
+      {
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+        other: {},
+      },
+      DEFAULT_CONTEXT,
+    ));
+  });
+
+  it('handles errors from lambda setup when run without requestContext', async () => {
+    const lambda = proxyquire('../src/aws-adapter.js', {
+      './main.js': {
+        main: () => {
+          throw new Error('function kaput');
+        },
+      },
+      './aws-package-params.js': () => {
+        throw new Error('package params kaput');
+      },
+    });
+    await assert.rejects(async () => lambda(
+      {
+        key1: 'value1',
+        key2: 'value2',
+        key3: 'value3',
+        other: {},
+      },
+      DEFAULT_CONTEXT,
+    ));
+  });
 });


### PR DESCRIPTION
When a function is not invoked via Gateway API (non-HTTP), report the error to the Lambda runtime (required for repeated delivery on failure and DLQ)