### PR TITLE
fix: ensure cookie header is not lost in aws

### DIFF
--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -29,9 +29,15 @@ const { AWSStorage } = require('./aws-storage');
  */
 async function lambdaAdapter(event, context, secrets = {}) {
   try {
+    // add cookie header if missing
+    const { headers } = event;
+    if (!headers.cookie && event.cookies) {
+      headers.cookie = event.cookies.join(';');
+    }
+
     const request = new Request(`https://${event.requestContext.domainName}${event.rawPath}${event.rawQueryString ? '?' : ''}${event.rawQueryString}`, {
       method: event.requestContext.http.method,
-      headers: event.headers,
+      headers,
       body: event.isBase64Encoded ? Buffer.from(event.body, 'base64') : event.body,
     });
 

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -344,6 +344,65 @@ describe('Adapter tests for AWS', () => {
     assert.equal(res.statusCode, 200);
   });
 
+  it('handles event cookies params', async () => {
+    const lambda = proxyquire('../src/aws-adapter.js', {
+      './main.js': {
+        // eslint-disable-next-line no-unused-vars
+        main: async (request, context) => {
+          assert.deepStrictEqual(request.headers.plain(), {
+            cookie: 'name1=value1;name2=value2',
+            host: 'kvvyh7ikcb.execute-api.us-east-1.amazonaws.com',
+          });
+          return new Response('okay');
+        },
+        '@noCallThru': true,
+      },
+      './aws-package-params.js': () => ({}),
+    });
+
+    const res = await lambda({
+      ...DEFAULT_EVENT,
+      cookies: [
+        'name1=value1',
+        'name2=value2',
+      ],
+      rawQueryString: 'foo=bar',
+      headers: {
+        host: 'kvvyh7ikcb.execute-api.us-east-1.amazonaws.com',
+      },
+    }, DEFAULT_CONTEXT);
+    assert.equal(res.statusCode, 200);
+  });
+
+  it('handles preserves cookie header', async () => {
+    const lambda = proxyquire('../src/aws-adapter.js', {
+      './main.js': {
+        // eslint-disable-next-line no-unused-vars
+        main: async (request, context) => {
+          assert.deepStrictEqual(request.headers.plain(), {
+            cookie: 'name1=value1;name2=value2',
+            host: 'kvvyh7ikcb.execute-api.us-east-1.amazonaws.com',
+          });
+          return new Response('okay');
+        },
+        '@noCallThru': true,
+      },
+      './aws-package-params.js': () => ({}),
+    });
+
+    const res = await lambda({
+      ...DEFAULT_EVENT,
+      cookies: [
+      ],
+      rawQueryString: 'foo=bar',
+      headers: {
+        host: 'kvvyh7ikcb.execute-api.us-east-1.amazonaws.com',
+        cookie: 'name1=value1;name2=value2',
+      },
+    }, DEFAULT_CONTEXT);
+    assert.equal(res.statusCode, 200);
+  });
+
   it('can be run without requestContext', async () => {
     const lambda = proxyquire('../src/aws-adapter.js', {
       './main.js': {


### PR DESCRIPTION
fixes #62
