### PR TITLE
feat: add namespace for context types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,7 +22,7 @@ import {UniversalContext as _UniversalContext} from './adapter';
  * ```ts
  * // Extend in a wrapper declaration via merging
  * declare module '@adobe/helix-universal' {
- *   namespace HelixUniversal {
+ *   namespace Helix {
  *     export interface UniversalContext {
  *       foo: () => void;
  *     }
@@ -33,18 +33,18 @@ import {UniversalContext as _UniversalContext} from './adapter';
  * @example
  * ```ts
  * // Use merged interface as a type
- * import { HelixUniversal } from '@adobe/helix-universal';
+ * import type { Helix } from '@adobe/helix-universal';
  * 
- * async function main(request: Request, context: HelixUniversal.UniversalContext) {
+ * async function main(request: Request, context: Helix.UniversalContext) {
  *   const bar = context.foo();
  * }
  * 
  * ```
  */
 declare module '@adobe/helix-universal' {
-  namespace HelixUniversal {
+  namespace Helix {
     export interface UniversalContext extends _UniversalContext {
-
+      [key: string]: unknown;
     }
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,3 +12,39 @@
 export { Request, Response } from '@adobe/helix-fetch';
 export { Resolver } from './resolver';
 export * from './adapter';
+
+import {UniversalContext as _UniversalContext} from './adapter';
+
+/**
+ * Namespace declaration with interfaces that wrappers can extend.
+ * 
+ * @example
+ * ```ts
+ * // Extend in a wrapper declaration via merging
+ * declare module '@adobe/helix-universal' {
+ *   namespace HelixUniversal {
+ *     export interface UniversalContext {
+ *       foo: () => void;
+ *     }
+ *   }
+ * }
+ * ```
+ * 
+ * @example
+ * ```ts
+ * // Use merged interface as a type
+ * import { HelixUniversal } from '@adobe/helix-universal';
+ * 
+ * async function main(request: Request, context: HelixUniversal.UniversalContext) {
+ *   const bar = context.foo();
+ * }
+ * 
+ * ```
+ */
+declare module '@adobe/helix-universal' {
+  namespace HelixUniversal {
+    export interface UniversalContext extends _UniversalContext {
+
+    }
+  }
+}


### PR DESCRIPTION
this is a minor change to avoid disrupting types elsewhere.. ideally we would use the namespace types internally and only declare the module namespace, imo

naming could be changed, like `HelixUniversal.Context` instead of `HelixUniversal.UniversalContext`?


ref: #70 
see also: https://github.com/adobe/helix-universal-logger/pull/51