### PR TITLE
feat: remove exports of request and response

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-export { Request, Response } from '@adobe/helix-fetch';
 export { Resolver } from './resolver';
 export * from './adapter';
 
@@ -17,7 +16,7 @@ import {UniversalContext as _UniversalContext} from './adapter';
 
 /**
  * Namespace declaration with interfaces that wrappers can extend.
- * 
+ *
  * @example
  * ```ts
  * // Extend in a wrapper declaration via merging
@@ -29,16 +28,16 @@ import {UniversalContext as _UniversalContext} from './adapter';
  *   }
  * }
  * ```
- * 
+ *
  * @example
  * ```ts
  * // Use merged interface as a type
  * import type { Helix } from '@adobe/helix-universal';
- * 
+ *
  * async function main(request: Request, context: Helix.UniversalContext) {
  *   const bar = context.foo();
  * }
- * 
+ *
  * ```
  */
 declare module '@adobe/helix-universal' {

--- a/src/index.js
+++ b/src/index.js
@@ -10,15 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-const { Request, Response } = require('@adobe/helix-fetch');
 const aws = require('./aws-adapter.js');
 const openwhisk = require('./openwhisk-adapter.js');
 const azure = require('./azure-adapter.js');
 const google = require('./google-adapter.js');
 
 module.exports = {
-  Request,
-  Response,
   adapter: {
     openwhisk,
     aws,


### PR DESCRIPTION
BREAKING CHANGE: Request/Response are not longer exported. use the ones from helix-fetch

