### PR TITLE
feat: return response body for non-http events

### DIFF
--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -95,13 +95,17 @@ async function lambdaAdapter(event, context) {
     if (con.log && con.log.flush) {
       await con.log.flush();
     }
-    const isBase64Encoded = isBinary(response.headers);
-    const body = isBase64Encoded ? Buffer.from(await response.arrayBuffer()).toString('base64') : await response.text();
 
     if (event.nonHttp) {
       // directly return response body
-      return body;
+      if (response.headers.get('content-type') === 'application/json') {
+        return await response.json();
+      }
+      return await response.text();
     }
+
+    const isBase64Encoded = isBinary(response.headers);
+    const body = isBase64Encoded ? Buffer.from(await response.arrayBuffer()).toString('base64') : await response.text();
 
     return {
       statusCode: response.status,

--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -96,11 +96,18 @@ async function lambdaAdapter(event, context) {
       await con.log.flush();
     }
     const isBase64Encoded = isBinary(response.headers);
+    const body = isBase64Encoded ? Buffer.from(await response.arrayBuffer()).toString('base64') : await response.text();
+
+    if (event.nonHttp) {
+      // directly return response body
+      return body;
+    }
+
     return {
       statusCode: response.status,
       headers: Object.fromEntries(response.headers.entries()),
       isBase64Encoded,
-      body: isBase64Encoded ? Buffer.from(await response.arrayBuffer()).toString('base64') : await response.text(),
+      body,
     };
   } catch (e) {
     if (e instanceof TypeError && e.code === 'ERR_INVALID_CHAR') {

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -577,7 +577,11 @@ describe('Adapter tests for AWS', () => {
           });
           const json = await request.json();
           assert.deepStrictEqual(json, messageBody);
-          return new Response('{}');
+          return new Response('{}', {
+            headers: {
+              'content-type': 'application/json',
+            },
+          });
         },
       },
       './aws-secrets.js': proxySecretsPlugin(awsSecretsPlugin),
@@ -590,7 +594,7 @@ describe('Adapter tests for AWS', () => {
       },
       DEFAULT_CONTEXT,
     );
-    assert.strictEqual(res, '{}');
+    assert.deepStrictEqual(res, {});
   });
 
   it('handles errors when run without requestContext', async () => {

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -549,7 +549,7 @@ describe('Adapter tests for AWS', () => {
       },
       DEFAULT_CONTEXT,
     );
-    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res, 'ok');
   });
 
   it('can be run as a trigger with context.records', async () => {
@@ -577,7 +577,7 @@ describe('Adapter tests for AWS', () => {
           });
           const json = await request.json();
           assert.deepStrictEqual(json, messageBody);
-          return new Response('ok');
+          return new Response('{}');
         },
       },
       './aws-secrets.js': proxySecretsPlugin(awsSecretsPlugin),
@@ -590,7 +590,7 @@ describe('Adapter tests for AWS', () => {
       },
       DEFAULT_CONTEXT,
     );
-    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res, '{}');
   });
 
   it('handles errors when run without requestContext', async () => {


### PR DESCRIPTION
use to return reponses to event trigger, eg:

https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting
