### PR TITLE
feat: support factory for main function

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "main": "src/index.js",
   "types": "src/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": "./src/index.js",
+    "./google": "./src/google-adapter.js",
+    "./aws": "./src/aws-adapter.js",
+    "./openwhisk": "./src/openwhisk-adapter.js"
+  },
   "scripts": {
     "test": "c8 mocha --spec=test/**/*.test.js",
     "lint": "eslint .",

--- a/src/google-adapter.js
+++ b/src/google-adapter.js
@@ -24,85 +24,100 @@ import { GoogleResolver } from './resolver.js';
 import { GoogleStorage } from './google-storage.js';
 
 /**
- * Universal adapter for google cloud functions.
- * @param {*} req express request
- * @param {*} res express response
+ * Creates a universal adapter for google cloud functions.
+ * @param {function} opts.factory the factory for the main function. defaults to dynamic import
+ * @param {object} opts options
  */
-async function googleAdapter(req, res) {
-  try {
-    const request = new Request(`https://${req.hostname}/${process.env.K_SERVICE}${req.originalUrl}`, {
-      method: req.method,
-      headers: req.headers,
-      // google magically does the right thing here
-      body: req.rawBody,
-    });
-
-    const [subdomain] = req.headers.host.split('.');
-    const [country, region, ...servicename] = subdomain.split('-');
-    const [packageName, name] = process.env.K_SERVICE.split('--');
-
-    const context = {
-      resolver: new GoogleResolver(req),
-      pathInfo: {
-        // original: /foo?hey=bar
-        suffix: req.originalUrl.replace(/\?.*/, ''),
-      },
-      runtime: {
-        name: 'googlecloud-functions',
-        region: `${country}-${region}`,
-      },
-      func: {
-        name,
-        package: packageName,
-        version: process.env.K_REVISION,
-        fqn: process.env.K_SERVICE,
-        app: servicename.join('-'),
-      },
-      invocation: {
-        id: req.headers['function-execution-id'],
-        deadline: Number.parseInt(req.headers['x-appengine-timeout-ms'], 10) + Date.now(),
-        transactionId: request.headers.get('x-transaction-id'),
-        requestId: request.headers.get('x-cloud-trace-context'),
-      },
-      env: {
-        ...process.env,
-      },
-      log: createDefaultLogger(),
-      storage: GoogleStorage,
-    };
-
-    updateProcessEnv(context);
-    const { main } = await import('./main.js');
-
-    const response = await main(request, context);
-    ensureUTF8Charset(response);
-    ensureInvocationId(response, context);
-
-    const body = isBinary(response.headers)
-      ? Buffer.from(await response.arrayBuffer())
-      : await response.text();
-    Array.from(response.headers.entries())
-      .reduce((r, [header, value]) => r.set(header, value), res.status(response.status))
-      .send(body);
-  } catch (e) {
-    if (e instanceof TypeError && e.code === 'ERR_INVALID_CHAR') {
-      // eslint-disable-next-line no-console
-      console.error('invalid request header', e.message);
-      res.status(400).send(e.message);
-      return;
-    }
-    // eslint-disable-next-line no-console
-    console.error('error while invoking function', e);
-    res
-      .status(500)
-      .set('content-type', 'text/plain')
-      .set('x-invocation-id', req.headers['function-execution-id'])
-      .set('x-error', cleanupHeaderValue(e.message))
-      .send(e.message);
+export function createAdapter(opts = {}) {
+  let { factory } = opts;
+  if (!factory) {
+    factory = async () => (await import('./main.js')).main;
   }
+
+  /**
+   * Universal adapter for google cloud functions.
+   * @param {*} req express request
+   * @param {*} res express response
+   */
+  return async function googleAdapter(req, res) {
+    try {
+      const request = new Request(`https://${req.hostname}/${process.env.K_SERVICE}${req.originalUrl}`, {
+        method: req.method,
+        headers: req.headers,
+        // google magically does the right thing here
+        body: req.rawBody,
+      });
+
+      const [subdomain] = req.headers.host.split('.');
+      const [country, region, ...servicename] = subdomain.split('-');
+      const [packageName, name] = process.env.K_SERVICE.split('--');
+
+      const context = {
+        resolver: new GoogleResolver(req),
+        pathInfo: {
+          // original: /foo?hey=bar
+          suffix: req.originalUrl.replace(/\?.*/, ''),
+        },
+        runtime: {
+          name: 'googlecloud-functions',
+          region: `${country}-${region}`,
+        },
+        func: {
+          name,
+          package: packageName,
+          version: process.env.K_REVISION,
+          fqn: process.env.K_SERVICE,
+          app: servicename.join('-'),
+        },
+        invocation: {
+          id: req.headers['function-execution-id'],
+          deadline: Number.parseInt(req.headers['x-appengine-timeout-ms'], 10) + Date.now(),
+          transactionId: request.headers.get('x-transaction-id'),
+          requestId: request.headers.get('x-cloud-trace-context'),
+        },
+        env: {
+          ...process.env,
+        },
+        log: createDefaultLogger(),
+        storage: GoogleStorage,
+      };
+
+      updateProcessEnv(context);
+      // create the `main` after the process.env is set. this gives the functions the ability to
+      // use process.env in their global scopes.
+      const main = await factory();
+
+      const response = await main(request, context);
+      ensureUTF8Charset(response);
+      ensureInvocationId(response, context);
+
+      const body = isBinary(response.headers)
+        ? Buffer.from(await response.arrayBuffer())
+        : await response.text();
+      Array.from(response.headers.entries())
+        .reduce((r, [header, value]) => r.set(header, value), res.status(response.status))
+        .send(body);
+    } catch (e) {
+      if (e instanceof TypeError && e.code === 'ERR_INVALID_CHAR') {
+        // eslint-disable-next-line no-console
+        console.error('invalid request header', e.message);
+        res.status(400).send(e.message);
+        return;
+      }
+      // eslint-disable-next-line no-console
+      console.error('error while invoking function', e);
+      res
+        .status(500)
+        .set('content-type', 'text/plain')
+        .set('x-invocation-id', req.headers['function-execution-id'])
+        .set('x-error', cleanupHeaderValue(e.message))
+        .send(e.message);
+    }
+  };
 }
 
-function wrap(adapter) {
+// export 'wrap' so it can be used like: `google.wrap(google.raw).with(epsagon).with(secrets);
+export function wrap(adapter) {
   /**
    * Universal adapter for google cloud functions.
    * @param {*} req express request
@@ -132,7 +147,4 @@ function wrap(adapter) {
 }
 
 // default export contains the aws secrets plugin
-export const google = wrap(googleAdapter).with(googleSecretsPlugin);
-// export 'wrap' so it can be used like: `google.wrap(google.raw).with(epsagon).with(secrets);
-google.wrap = wrap;
-google.raw = googleAdapter;
+export const google = wrap(createAdapter()).with(googleSecretsPlugin);

--- a/src/openwhisk-adapter.js
+++ b/src/openwhisk-adapter.js
@@ -24,106 +24,125 @@ import {
 import { OpenwhiskResolver } from './resolver.js';
 
 /**
- * The universal adapter for openwhisk actions.
- * @param {object} params openwhisk action params.
- * @returns {*} openwhisk response
+ * Creates a universal adapter for google cloud functions.
+ * @param {function} opts.factory the factory for the main function. defaults to dynamic import
+ * @param {object} opts options
  */
-async function openwhiskAdapter(params) {
-  const {
-    __ow_method: method = 'GET',
-    __ow_headers: headers = {},
-    __ow_path: suffix = '',
-    __ow_body: rawBody = '',
-    __ow_query: query = '',
-    ...rest
-  } = params;
+export function createAdapter(opts = {}) {
+  let { factory } = opts;
+  if (!factory) {
+    factory = async () => (await import('./main.js')).main;
+  }
 
-  let body;
-  if (!/^(GET|HEAD)$/i.test(method)) {
-    body = isBinaryType(headers['content-type'])
-      ? Buffer.from(rawBody, 'base64')
-      : rawBody;
-    // binaries and JSON (!) are base64 encoded
-    if (/application\/json/.test(headers['content-type'])) {
-      body = Buffer.from(rawBody, 'base64').toString('utf-8');
+  /**
+   * The universal adapter for openwhisk actions.
+   * @param {object} params openwhisk action params.
+   * @returns {*} openwhisk response
+   */
+  return async function openwhiskAdapter(params) {
+    const {
+      __ow_method: method = 'GET',
+      __ow_headers: headers = {},
+      __ow_path: suffix = '',
+      __ow_body: rawBody = '',
+      __ow_query: query = '',
+      ...rest
+    } = params;
+
+    let body;
+    if (!/^(GET|HEAD)$/i.test(method)) {
+      body = isBinaryType(headers['content-type'])
+        ? Buffer.from(rawBody, 'base64')
+        : rawBody;
+      // binaries and JSON (!) are base64 encoded
+      if (/application\/json/.test(headers['content-type'])) {
+        body = Buffer.from(rawBody, 'base64')
+          .toString('utf-8');
+      }
     }
-  }
 
-  const env = { ...process.env };
-  delete env.__OW_API_KEY;
-  let host = env.__OW_API_HOST || 'https://localhost';
-  if (typeof headers['x-forwarded-host'] === 'string') {
-    host = `https://${headers['x-forwarded-host'].split(',')[0].trim()}`;
-  }
-  const url = new URL(`${host}/api/v1/web${process.env.__OW_ACTION_NAME}${suffix}`);
+    const env = { ...process.env };
+    delete env.__OW_API_KEY;
+    let host = env.__OW_API_HOST || 'https://localhost';
+    if (typeof headers['x-forwarded-host'] === 'string') {
+      host = `https://${headers['x-forwarded-host'].split(',')[0].trim()}`;
+    }
+    const url = new URL(`${host}/api/v1/web${process.env.__OW_ACTION_NAME}${suffix}`);
 
-  // add query to params
-  if (query) {
-    Object.entries(querystring.parse(query)).forEach(([key, value]) => {
-      url.searchParams.append(key, value);
+    // add query to params
+    if (query) {
+      Object.entries(querystring.parse(query))
+        .forEach(([key, value]) => {
+          url.searchParams.append(key, value);
+        });
+    }
+    // add additional params for actions invoked via wsk
+    Object.entries(rest)
+      .forEach(([key, value]) => {
+        if (key.match(/^[A-Z0-9_]+$/)) {
+          env[key] = value;
+        } else {
+          url.searchParams.append(key, value);
+        }
+      });
+    const request = new Request(url.toString(), {
+      method,
+      headers,
+      body,
     });
-  }
-  // add additional params for actions invoked via wsk
-  Object.entries(rest).forEach(([key, value]) => {
-    if (key.match(/^[A-Z0-9_]+$/)) {
-      env[key] = value;
-    } else {
-      url.searchParams.append(key, value);
-    }
-  });
-  const request = new Request(url.toString(), {
-    method,
-    headers,
-    body,
-  });
 
-  const fqn = process.env.__OW_ACTION_NAME;
-  const segments = fqn.split('/');
-  const [name, version] = segments.pop().split('@');
-  const packageName = segments.pop();
+    const fqn = process.env.__OW_ACTION_NAME;
+    const segments = fqn.split('/');
+    const [name, version] = segments.pop()
+      .split('@');
+    const packageName = segments.pop();
 
-  const context = {
-    resolver: new OpenwhiskResolver(params),
-    pathInfo: {
-      suffix,
-    },
-    runtime: {
-      name: 'apache-openwhisk',
-      region: process.env.__OW_REGION,
-    },
-    func: {
-      name,
-      version,
-      package: packageName,
-      app: process.env.__OW_NAMESPACE,
-      fqn,
-    },
-    invocation: {
-      id: process.env.__OW_ACTIVATION_ID,
-      deadline: Number.parseInt(process.env.__OW_DEADLINE, 10),
-      transactionId: headers['x-transaction-id'] || process.env.__OW_TRANSACTION_ID,
-      requestId: headers['x-request-id'],
-    },
-    env,
-    log: createDefaultLogger(),
-  };
+    const context = {
+      resolver: new OpenwhiskResolver(params),
+      pathInfo: {
+        suffix,
+      },
+      runtime: {
+        name: 'apache-openwhisk',
+        region: process.env.__OW_REGION,
+      },
+      func: {
+        name,
+        version,
+        package: packageName,
+        app: process.env.__OW_NAMESPACE,
+        fqn,
+      },
+      invocation: {
+        id: process.env.__OW_ACTIVATION_ID,
+        deadline: Number.parseInt(process.env.__OW_DEADLINE, 10),
+        transactionId: headers['x-transaction-id'] || process.env.__OW_TRANSACTION_ID,
+        requestId: headers['x-request-id'],
+      },
+      env,
+      log: createDefaultLogger(),
+    };
 
-  updateProcessEnv(context);
-  const { main } = await import('./main.js');
+    updateProcessEnv(context);
+    // create the `main` after the process.env is set. this gives the functions the ability to
+    // use process.env in their global scopes.
+    const main = await factory();
 
-  const response = await main(request, context);
-  ensureUTF8Charset(response);
-  ensureInvocationId(response, context);
+    const response = await main(request, context);
+    ensureUTF8Charset(response);
+    ensureInvocationId(response, context);
 
-  const isBase64Encoded = isBinary(response.headers);
-  return {
-    statusCode: response.status,
-    headers: Object.fromEntries(response.headers.entries()),
-    body: isBase64Encoded ? Buffer.from(await response.arrayBuffer()).toString('base64') : await response.text(),
+    const isBase64Encoded = isBinary(response.headers);
+    return {
+      statusCode: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      body: isBase64Encoded ? Buffer.from(await response.arrayBuffer())
+        .toString('base64') : await response.text(),
+    };
   };
 }
 
-function wrap(adapter) {
+export function wrap(adapter) {
   /**
    * Universal adapter for openwhisk actions
    * @param {*} params openwhisk params
@@ -176,8 +195,4 @@ function wrap(adapter) {
   return wrapped;
 }
 
-// default export contains the aws secrets plugin
-export const openwhisk = wrap(openwhiskAdapter);
-// export 'wrap' so it can be used like: `openwhisk.wrap(openwhisk.raw).with(epsagon).with(secrets);
-openwhisk.wrap = wrap;
-openwhisk.raw = openwhiskAdapter;
+export const openwhisk = wrap(createAdapter());


### PR DESCRIPTION
allows passing in the main function via a factory, thus makes it easier for projects to use the adapter out of the universal context. eg:

```js
import { createAdapter } from '@adobe/helix-universal/google';

async function main(req, context) {
...
}

const handler = createAdapter({ factory: () => (main) });
const app = express();
this.app.all('*', handler);
```

furthermore, it might help later to create a ESM only bundle where the dynamic import is controlled in the helix-deploy template and not in helix-universal....