### PR TITLE
feat: support throwing errors with custom http status codes

### DIFF
--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -216,7 +216,7 @@ export function createAdapter(opts = {}) {
         throw e;
       }
       return {
-        statusCode: 500,
+        statusCode: e.statusCode || 500,
         headers: {
           'content-type': 'text/plain',
           'x-error': cleanupHeaderValue(e.message),

--- a/src/google-adapter.js
+++ b/src/google-adapter.js
@@ -107,7 +107,7 @@ export function createAdapter(opts = {}) {
       // eslint-disable-next-line no-console
       console.error('error while invoking function', e);
       res
-        .status(500)
+        .status(e.statusCode || 500)
         .set('content-type', 'text/plain')
         .set('x-invocation-id', req.headers['function-execution-id'])
         .set('x-error', cleanupHeaderValue(e.message))

--- a/src/openwhisk-adapter.js
+++ b/src/openwhisk-adapter.js
@@ -175,13 +175,13 @@ export function wrap(adapter) {
       // eslint-disable-next-line no-console
       console.error('error while invoking function', e);
       return {
-        statusCode: 500,
+        statusCode: e.statusCode || 500,
         headers: {
           'Content-Type': 'text/plain',
           'x-invocation-id': process.env.__OW_ACTIVATION_ID,
           'x-error': cleanupHeaderValue(e.message),
         },
-        body: 'Internal Server Error',
+        body: (typeof e.statusCode === 'undefined' || e.statusCode === 500) ? 'Internal Server Error' : e.message,
       };
     }
   };

--- a/test/openwhisk-adapter.test.js
+++ b/test/openwhisk-adapter.test.js
@@ -475,4 +475,31 @@ describe('OpenWhisk Adapter Test', () => {
       'plugin1 after',
     ]);
   });
+
+  it('handles throwing error with custom status code', async () => {
+    const { openwhisk: main } = await esmock.p('../src/openwhisk-adapter.js', {
+      '../src/main.js': {
+        main: () => {
+          const error = new Error('unauthorized - custom message');
+          error.statusCode = 403;
+          throw error;
+        },
+
+      },
+    });
+
+    const resp = await main({
+      __ow_headers: {
+        'x-forwarded-host': 'adobeioruntime.net,test.com',
+      },
+    });
+    console.log(resp);
+    assert.strictEqual(resp.statusCode, 403);
+    assert.strictEqual(resp.body, 'unauthorized - custom message');
+    assert.deepStrictEqual(resp.headers, {
+      'Content-Type': 'text/plain',
+      'x-error': 'unauthorized - custom message',
+      'x-invocation-id': '1234',
+    });
+  });
 });


### PR DESCRIPTION
Proposal as discussed with @tripodsan on slack.

There is existing code that would pass along an `e.statusCode` from a caught error in the adapters into the HTTP response, but there were other try/catches inside that forced them into a 500. This changes that it's passed through and adds tests for it.

Notes:
- changed AWS, Google & Openwhisk adapters, I hope I got all?
- this is the most minimal change, not requiring a custom 
- in the openwhisk adapter an existing test expects "Internal Server Error" for 500 in the body (but the custom message in the `x-error` header), so I had to make a check for 500 to keep that behaviour in case something relies on it
- otherwise the behavior puts the same `e.message` into both body (plain text) and `x-error` header
  - not sure if there are cases to have them differ (e.g. shorter message in `x-error`, longer in body)? similarly support a custom content type?
  - in my use case the key part is to control the status code (e.g. return 401 or 403 for auth failures)