### PR TITLE
fix: stop using multiHeadersValue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "lint-staged": "15.2.5",
         "mocha": "10.4.0",
         "mocha-multi-reporters": "^1.5.1",
+        "mocha-suppress-logs": "0.5.1",
         "nock": "13.5.4",
         "semantic-release": "23.1.1"
       }
@@ -2150,6 +2151,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -5662,6 +5673,16 @@
       },
       "peerDependencies": {
         "mocha": ">=3.1.2"
+      }
+    },
+    "node_modules/mocha-suppress-logs": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mocha-suppress-logs/-/mocha-suppress-logs-0.5.1.tgz",
+      "integrity": "sha512-f4BhMiCABgCt3tlXiOcRydWreNCkfvgXgNL2ZclfXPdLNcY7jfyNy3Oi5wwPuxx++UyuNiIx3F7orvckAfrKzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2"
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
@@ -12939,6 +12960,12 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -15539,6 +15566,15 @@
       "requires": {
         "debug": "^4.1.1",
         "lodash": "^4.17.15"
+      }
+    },
+    "mocha-suppress-logs": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mocha-suppress-logs/-/mocha-suppress-logs-0.5.1.tgz",
+      "integrity": "sha512-f4BhMiCABgCt3tlXiOcRydWreNCkfvgXgNL2ZclfXPdLNcY7jfyNy3Oi5wwPuxx++UyuNiIx3F7orvckAfrKzw==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.2"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "reporter-options": "configFile=.mocha-multi.json",
     "loader": "esmock",
     "require": [
-      "test/setup-env.js"
+      "test/setup-env.js",
+      "mocha-suppress-logs"
     ]
   },
   "homepage": "https://github.com/adobe/helix-universal#readme",
@@ -56,6 +57,7 @@
     "lint-staged": "15.2.5",
     "mocha": "10.4.0",
     "mocha-multi-reporters": "^1.5.1",
+    "mocha-suppress-logs": "0.5.1",
     "nock": "13.5.4",
     "semantic-release": "23.1.1"
   },

--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -55,7 +55,12 @@ function splitHeaders(raw) {
 
   Object.entries(raw).forEach(([name, value]) => {
     if (Array.isArray(value)) {
-      multiValueHeaders[name] = value;
+      if (name.toLowerCase() === 'vary') {
+        // remedy for AWS HTTP API Gateway bug
+        headers[name] = value.join(', ');
+      } else {
+        multiValueHeaders[name] = value;
+      }
     } else {
       headers[name] = value;
     }

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -524,7 +524,6 @@ describe('Adapter tests for AWS', () => {
   it('handles multiple set-cookie headers', async () => {
     const { lambda } = await esmock.p('../src/aws-adapter.js', {
       '../src/main.js': {
-        // eslint-disable-next-line no-unused-vars
         main: async () => {
           const headers = new Headers();
           headers.append('set-cookie', 't=1; Secure');
@@ -545,7 +544,7 @@ describe('Adapter tests for AWS', () => {
       },
     }, DEFAULT_CONTEXT);
     assert.strictEqual(res.statusCode, 200);
-    assert.deepStrictEqual(res.multiValueHeaders['set-cookie'], [
+    assert.deepStrictEqual(res.cookies, [
       't=1; Secure',
       'u=2; Secure',
     ]);
@@ -554,7 +553,6 @@ describe('Adapter tests for AWS', () => {
   it('handles multiple vary headers', async () => {
     const { lambda } = await esmock.p('../src/aws-adapter.js', {
       '../src/main.js': {
-        // eslint-disable-next-line no-unused-vars
         main: async () => {
           const headers = new Headers();
           headers.append('vary', 'x-forwarded-host');
@@ -576,6 +574,32 @@ describe('Adapter tests for AWS', () => {
     }, DEFAULT_CONTEXT);
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(res.headers.vary, 'x-forwarded-host, accept-encoding');
+  });
+
+  it('handles other multi header value', async () => {
+    const { lambda } = await esmock.p('../src/aws-adapter.js', {
+      '../src/main.js': {
+        main: async () => {
+          const headers = new Headers();
+          headers.append('x-surrogate-key', '1');
+          headers.append('x-surrogate-key', '2');
+          return new Response('okay', { headers });
+        },
+      },
+      '../src/aws-secrets.js': proxySecretsPlugin(awsSecretsPlugin),
+    });
+
+    const res = await lambda({
+      ...DEFAULT_EVENT,
+      cookies: [
+      ],
+      rawQueryString: 'foo=bar',
+      headers: {
+        host: 'kvvyh7ikcb.execute-api.us-east-1.amazonaws.com',
+      },
+    }, DEFAULT_CONTEXT);
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.headers['x-surrogate-key'], '1 2');
   });
 
   it('can be run without requestContext', async () => {


### PR DESCRIPTION
with the new payload format 2.0, AWS HTTP API Gateway no longer seems to accept `multiHeadersValue` in the response