### PR TITLE
fix: combine server-timing with comma

### DIFF
--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -59,6 +59,7 @@ function splitHeaders(raw, log) {
       const lwrname = name.toLowerCase();
       switch (lwrname) {
         case 'vary':
+        case 'server-timing':
           headers[name] = value.join(', ');
           break;
         case 'set-cookie':


### PR DESCRIPTION
It currently is combined with spaces, along with a warning in the logs.
