### PR TITLE
feat(aws): export default factory next to raw adapter

### DIFF
--- a/src/aws-adapter.js
+++ b/src/aws-adapter.js
@@ -114,6 +114,15 @@ export function responseTooLarge(resp) {
 }
 
 /**
+ * Create a default factory to retrieve the main entry point of a service.
+ *
+ * @returns {function} default factory
+ */
+export function createDefaultFactory() {
+  return async () => (await import('./main.js')).main;
+}
+
+/**
  * Creates a universal adapter for google cloud functions.
  * @param {function} opts.factory the factory for the main function. defaults to dynamic import
  * @param {object} opts options
@@ -121,7 +130,7 @@ export function responseTooLarge(resp) {
 export function createAdapter(opts = {}) {
   let { factory } = opts;
   if (!factory) {
-    factory = async () => (await import('./main.js')).main;
+    factory = createDefaultFactory();
   }
 
   /**
@@ -323,5 +332,6 @@ export function wrap(adapter) {
 // default export contains the aws secrets plugin
 export const lambda = wrap(createAdapter()).with(awsSecretsPlugin);
 
-// create raw adapter for easier testing
+// create raw adapter and factory for easier testing
 lambda.raw = createAdapter();
+lambda.factory = createDefaultFactory();

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@
  * dummy function to make esmock/eslint happy.
  * this file is excluded in npm package.
  */
-/* c8 ignore next 2 */
-export default function main() {
+/* c8 ignore next 3 */
+export function main() {
+  return new Response('this file is excluded in npm package.');
 }

--- a/test/aws-adapter.test.js
+++ b/test/aws-adapter.test.js
@@ -117,6 +117,18 @@ describe('Adapter tests for AWS', () => {
     assert.strictEqual(res.statusCode, 200);
   });
 
+  it('can use `main` created by the default factory directly', async () => {
+    const { createDefaultFactory } = await esmock.p('../src/aws-adapter.js');
+    const factory = await createDefaultFactory();
+    const main = await factory();
+
+    // this will call code in `./src/main.js`
+    const res = await main();
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(await res.text(), 'this file is excluded in npm package.');
+    assert(res);
+  });
+
   it('default can wrap more plugins', async () => {
     const invocations = [];
     const { lambda } = await esmock.p('../src/aws-adapter.js', {


### PR DESCRIPTION
Allows to import the factory from a bundle build and invoke tests written against the `main` entry of a service in the bundle itself.